### PR TITLE
FEAT : BDBD-153 게시글 등록 기능 mock up api 만들기

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@
   <img src="https://img.shields.io/badge/java-007396?style=for-the-badge&logo=java&logoColor=white">
   <img src="https://img.shields.io/badge/Spring-6DB33F?style=for-the-badge&logo=Spring&logoColor=white">
   <img src="https://img.shields.io/badge/Spring%20Boot-6DB33F?style=for-the-badge&logo=Spring%20Boot&logoColor=white">
-  <br>
-  <img src="https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=HTML5&logoColor=white">
-  <img src="https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=CSS3&logoColor=white">
-  <img src="https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=JavaScript&logoColor=white">
-  <img src="https://img.shields.io/badge/Vue.js-4FC08D?style=for-the-badge&logo=Vue.js&logoColor=white">
+  <img src="https://img.shields.io/badge/Hibernate-59666C?style=for-the-badge&logo=Hibernate&logoColor=white">
+  <img src="https://img.shields.io/badge/Swagger-85EA2D?style=for-the-badge&logo=Swagger&logoColor=white">
   <br>
   <img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=GitHub&logoColor=white">
   <img src="https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=Git&logoColor=white">
   <img src="https://img.shields.io/badge/Jira%20Software-0052CC?style=for-the-badge&logo=Jira%20Software&logoColor=white">
   <img src="https://img.shields.io/badge/Confluence-172B4D?style=for-the-badge&logo=Confluence&logoColor=white">
+  <br>
 </div>

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/AuctionProjectApplication.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/AuctionProjectApplication.java
@@ -2,7 +2,9 @@ package com.fakedevelopers.ddangddangmarket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class AuctionProjectApplication {
 

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/config/StringToLocalDateTimeConverter.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/config/StringToLocalDateTimeConverter.java
@@ -1,0 +1,19 @@
+package com.fakedevelopers.ddangddangmarket.config;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+// String 형태로 입력받은 마감날짜를 LocalDateTime 형태로 바꿔줌
+public class StringToLocalDateTimeConverter implements Converter<String, LocalDateTime> {
+
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    @Override
+    public LocalDateTime convert(String source) {
+        return LocalDateTime.parse(source, formatter);
+    }
+}

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/controller/BoardController.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/controller/BoardController.java
@@ -1,0 +1,41 @@
+package com.fakedevelopers.ddangddangmarket.controller;
+
+import com.fakedevelopers.ddangddangmarket.dto.BoardWriteDto;
+import com.fakedevelopers.ddangddangmarket.model.BoardEntity;
+import com.fakedevelopers.ddangddangmarket.service.BoardService;
+import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/board")
+public class BoardController {
+
+    private final BoardService boardService;
+
+    BoardController(BoardService boardService) {
+        this.boardService = boardService;
+    }
+
+    // 게시글 작성
+    @PostMapping(value = "/write", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    String boardWrite(@Validated BoardWriteDto boardWriteDto,
+                      @RequestPart(required = false) List<MultipartFile> files) throws Exception {
+        boardService.saveBoard(boardWriteDto, files);
+        return "success";
+    }
+
+    // 게시글 전체 찾기
+    @GetMapping("/getAll")
+    List<BoardEntity> getAllBoards() {
+        return boardService.getAllBoards();
+    }
+
+}

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/dto/BoardWriteDto.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/dto/BoardWriteDto.java
@@ -1,0 +1,28 @@
+package com.fakedevelopers.ddangddangmarket.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class BoardWriteDto {
+    @NotBlank(message = "제목에 빈칸은 입력불가입니다.")
+    private final String board_title;
+
+    @NotBlank(message = "내용에 빈칸은 입력불가입니다.")
+    private final String board_content;
+
+    private final long opening_bid;
+
+    private final long tick;
+
+    private final String hope_bid;
+
+    private final int category;
+
+    private final LocalDateTime end_date;
+
+}

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/dto/BoardWriteDto.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/dto/BoardWriteDto.java
@@ -3,6 +3,7 @@ package com.fakedevelopers.ddangddangmarket.dto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 
@@ -17,6 +18,7 @@ public class BoardWriteDto {
 
     private final long opening_bid;
 
+    @Min(1)
     private final long tick;
 
     private final Long hope_price;

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/dto/BoardWriteDto.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/dto/BoardWriteDto.java
@@ -19,7 +19,7 @@ public class BoardWriteDto {
 
     private final long tick;
 
-    private final String hope_bid;
+    private final Long hope_price;
 
     private final int category;
 

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/model/BoardEntity.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/model/BoardEntity.java
@@ -19,8 +19,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.OneToMany;
+import javax.validation.constraints.Min;
 import java.io.File;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +44,7 @@ public class BoardEntity {
     private String board_title;
 
     // 게시글 내용
-    @Lob
+    @Column(nullable = false, length = 3000)
     private String board_content;
 
     // 시작가
@@ -52,11 +52,11 @@ public class BoardEntity {
     private long opening_bid;
 
     // 희망가
-    @Column
-    private Long hope_bid;
+    private Long hope_price;
 
     // 호가
     @Column(nullable = false)
+    @Min(1)
     private long tick;
 
     // 등록시간
@@ -90,7 +90,7 @@ public class BoardEntity {
         board_title = boardWriteDto.getBoard_title();
         board_content = boardWriteDto.getBoard_content();
         opening_bid = boardWriteDto.getOpening_bid();
-        hope_bid = getHopeBid(boardWriteDto);
+        hope_price = boardWriteDto.getHope_price();
         tick = boardWriteDto.getTick();
         category = findCategory(boardWriteDto.getCategory());
         end_date = boardWriteDto.getEnd_date();
@@ -120,17 +120,4 @@ public class BoardEntity {
         }
         throw new Exception("카테고리가 없어요");
     }
-
-    // 희망가 있는지 없는지 확인 후 반환
-    private Long getHopeBid(BoardWriteDto boardWriteDto) {
-        Long hope;
-
-        if (boardWriteDto.getHope_bid().isBlank()) {
-            hope = null;
-        } else {
-            hope = Long.parseLong(boardWriteDto.getHope_bid());
-        }
-        return hope;
-    }
-
 }

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/model/BoardEntity.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/model/BoardEntity.java
@@ -1,0 +1,136 @@
+package com.fakedevelopers.ddangddangmarket.model;
+
+import com.fakedevelopers.ddangddangmarket.dto.BoardWriteDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.OneToMany;
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class BoardEntity {
+
+    // 게시글 고유 번호
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long board_id;
+
+    // 게시글 제목
+    @Column(nullable = false, length = 300)
+    private String board_title;
+
+    // 게시글 내용
+    @Lob
+    private String board_content;
+
+    // 시작가
+    @Column(nullable = false)
+    private long opening_bid;
+
+    // 희망가
+    @Column
+    private Long hope_bid;
+
+    // 호가
+    @Column(nullable = false)
+    private long tick;
+
+    // 등록시간
+    @Column
+    @CreatedDate
+    private LocalDateTime created_time;
+
+    // 수정시간
+    @Column
+    @LastModifiedDate
+    private LocalDateTime modified_time;
+
+    // 카테고리
+    @Column(nullable = false)
+    private Category category;
+
+    // 경매 만료일
+    @Column(nullable = false)
+    private LocalDateTime end_date;
+
+    // 유저 DB 외래키
+//    @ManyToOne(targetEntity = User)
+//    @JoinColumn(name = "user_id")
+//    private long user_id;
+
+    // 파일
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, mappedBy = "boardEntity")
+    private List<FileEntity> fileEntities;
+
+    public BoardEntity(String path, BoardWriteDto boardWriteDto, List<MultipartFile> files) throws Exception {
+        board_title = boardWriteDto.getBoard_title();
+        board_content = boardWriteDto.getBoard_content();
+        opening_bid = boardWriteDto.getOpening_bid();
+        hope_bid = getHopeBid(boardWriteDto);
+        tick = boardWriteDto.getTick();
+        category = findCategory(boardWriteDto.getCategory());
+        end_date = boardWriteDto.getEnd_date();
+        fileEntities = makeFileEntityList(path, files);
+    }
+
+    // 파일 엔티티 리스트 만듦
+    private List<FileEntity> makeFileEntityList(String path, List<MultipartFile> files) throws Exception {
+        List<FileEntity> list = new ArrayList<>();
+
+        if (files != null) {
+            for (MultipartFile file : files) {
+                String savedFileName = UUID.randomUUID().toString();
+                list.add(new FileEntity(path, savedFileName, this, file));
+                file.transferTo(new File(path, savedFileName));
+            }
+        }
+        return list;
+    }
+
+    // 입력 받은 카테고리 있는지 확인 후 반환
+    private Category findCategory(int category) throws Exception {
+        for (Category c : Category.values()) {
+            if (c.ordinal() == category) {
+                return c;
+            }
+        }
+        throw new Exception("카테고리가 없어요");
+    }
+
+    // 희망가 있는지 없는지 확인 후 반환
+    private Long getHopeBid(BoardWriteDto boardWriteDto) {
+        Long hope;
+
+        if (boardWriteDto.getHope_bid().isBlank()) {
+            hope = null;
+        } else {
+            hope = Long.parseLong(boardWriteDto.getHope_bid());
+        }
+        return hope;
+    }
+
+}

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/model/BoardEntity.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/model/BoardEntity.java
@@ -56,7 +56,6 @@ public class BoardEntity {
 
     // 호가
     @Column(nullable = false)
-    @Min(1)
     private long tick;
 
     // 등록시간

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/model/Category.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/model/Category.java
@@ -1,0 +1,8 @@
+package com.fakedevelopers.ddangddangmarket.model;
+
+// 상의 후 제대로 정하자
+public enum Category {
+    FOOD,
+    COOK,
+    TOY
+}

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/model/FileEntity.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/model/FileEntity.java
@@ -22,7 +22,7 @@ public class FileEntity {
     // 파일 번호
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long file_id;
+    private long fileId;
 
     // 파일 경로
     @Column(nullable = false)

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/model/FileEntity.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/model/FileEntity.java
@@ -1,0 +1,49 @@
+package com.fakedevelopers.ddangddangmarket.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class FileEntity {
+
+    // 파일 번호
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long file_id;
+
+    // 파일 경로
+    @Column(nullable = false)
+    private String filePath;
+
+    // 파일명
+    @Column(nullable = false)
+    private String realFileName;
+
+    // 저장할 파일명
+    @Column(nullable = false)
+    private String savedFileName;
+
+    @ManyToOne
+    @JsonIgnore
+    private BoardEntity boardEntity;
+
+    public FileEntity(String filePath, String savedFileName, BoardEntity boardEntity, MultipartFile multipartFile) {
+        this.filePath = filePath;
+        this.savedFileName = savedFileName;
+        this.boardEntity = boardEntity;
+        realFileName = multipartFile.getOriginalFilename();
+    }
+}

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/repository/BoardRepository.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package com.fakedevelopers.ddangddangmarket.repository;
+
+import com.fakedevelopers.ddangddangmarket.model.BoardEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
+}

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/service/BoardService.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/service/BoardService.java
@@ -41,7 +41,7 @@ public class BoardService {
 
     // 시작가가 희망가보다 적은지 확인
     public void compareBids(BoardWriteDto boardWriteDto) throws Exception {
-        if (!(boardWriteDto.getHope_price() == null)) {
+        if ((boardWriteDto.getHope_price() != null)) {
             if (boardWriteDto.getHope_price() < boardWriteDto.getOpening_bid()) {
                 throw new Exception("희망가가 시작가보다 적어 ㅠㅠ ");
             }

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/service/BoardService.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/service/BoardService.java
@@ -9,7 +9,6 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.servlet.ServletContext;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
@@ -42,9 +41,9 @@ public class BoardService {
 
     // 시작가가 희망가보다 적은지 확인
     public void compareBids(BoardWriteDto boardWriteDto) throws Exception {
-        if (!boardWriteDto.getHope_bid().isBlank()) {
-            if (Long.parseLong(boardWriteDto.getHope_bid()) < boardWriteDto.getOpening_bid()) {
-                throw new Exception("시작가가 희망가보다 적어 ㅠㅠ ");
+        if (!(boardWriteDto.getHope_price() == null)) {
+            if (boardWriteDto.getHope_price() < boardWriteDto.getOpening_bid()) {
+                throw new Exception("희망가가 시작가보다 적어 ㅠㅠ ");
             }
         }
     }

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/service/BoardService.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/service/BoardService.java
@@ -41,7 +41,7 @@ public class BoardService {
 
     // 시작가가 희망가보다 적은지 확인
     public void compareBids(BoardWriteDto boardWriteDto) throws Exception {
-        if ((boardWriteDto.getHope_price() != null)) {
+        if (boardWriteDto.getHope_price() != null) {
             if (boardWriteDto.getHope_price() < boardWriteDto.getOpening_bid()) {
                 throw new Exception("희망가가 시작가보다 적어 ㅠㅠ ");
             }

--- a/src/main/java/com/fakedevelopers/ddangddangmarket/service/BoardService.java
+++ b/src/main/java/com/fakedevelopers/ddangddangmarket/service/BoardService.java
@@ -1,0 +1,86 @@
+package com.fakedevelopers.ddangddangmarket.service;
+
+import com.fakedevelopers.ddangddangmarket.dto.BoardWriteDto;
+import com.fakedevelopers.ddangddangmarket.model.BoardEntity;
+import com.fakedevelopers.ddangddangmarket.repository.BoardRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.servlet.ServletContext;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class BoardService {
+
+    private final static String RESOURCE_PATH = "/resources/upload";
+    private final BoardRepository boardRepository;
+    ServletContext servletContext;
+
+    BoardService(BoardRepository boardRepository, ServletContext servletContext) {
+        this.boardRepository = boardRepository;
+        this.servletContext = servletContext;
+    }
+
+    // 게시글 저장
+    public void saveBoard(BoardWriteDto boardWriteDto, List<MultipartFile> files) throws Exception {
+        compareBids(boardWriteDto);
+        compareDate(boardWriteDto);
+        compareExtension(files);
+        String path = createPathIfNeed();
+        BoardEntity boardEntity = new BoardEntity(path, boardWriteDto, files);
+
+        boardRepository.save(boardEntity);
+    }
+
+    // 시작가가 희망가보다 적은지 확인
+    public void compareBids(BoardWriteDto boardWriteDto) throws Exception {
+        if (!boardWriteDto.getHope_bid().isBlank()) {
+            if (Long.parseLong(boardWriteDto.getHope_bid()) < boardWriteDto.getOpening_bid()) {
+                throw new Exception("시작가가 희망가보다 적어 ㅠㅠ ");
+            }
+        }
+    }
+
+    // 경매 마감 날짜가 지금 날짜보다 나중인지 확인
+    public void compareDate(BoardWriteDto boardWriteDto) throws Exception {
+        if (boardWriteDto.getEnd_date().isBefore(LocalDateTime.now())) {
+            throw new Exception("마감 날짜가 지금 날짜보다 빨라요");
+        }
+    }
+
+    // 파일 확장자 jpg, png, jpeg 아니면 안되게 했음 -> 확장자도 얘기 후 조정
+    // 특정 확장자만 선택하게 하는건 프론트엔드에서도 가능
+    // 백엔드에서도 확인하는게 좋으니 양쪽에서 특정 확장자를 맞춰야겠네요
+    public void compareExtension(List<MultipartFile> files) throws Exception {
+        for(MultipartFile file : files){
+            String fileOriginName = file.getOriginalFilename();
+            String extension = fileOriginName.split("\\.")[1];
+            if(!(extension.equals("jpg") | extension.equals("png") | extension.equals("jpeg"))){
+                throw new Exception("이미지 파일 아님");
+            }
+        }
+    }
+
+    // 파일 경로 생성
+    private String createPathIfNeed() throws IOException {
+        String realPath = servletContext.getRealPath(RESOURCE_PATH);
+        String today = new SimpleDateFormat("yyMMdd").format(new Date());
+        String path = realPath + File.separator + today;
+        Files.createDirectories(Path.of(path));
+        return path;
+    }
+
+    // 게시글 검색
+    public List<BoardEntity> getAllBoards() {
+        return boardRepository.findAll();
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.MariaDB103Dialect
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher


### PR DESCRIPTION
### 개요
 - 게시글 등록 기능 mock up api

### 변경사항
 - 게시글 제목, 내용, 상품 이미지, 시작가, 호가, 희망가, 경매 마감일, 카테고리 입력 값을 DB에 저장
 - 게시글 등록 날짜 자동으로 저장
 - jpg, jpeg, png 확장자가 아니면 오류 메세지
 - 시작가가 희망가보다 적을시 오류 메세지
 - 경매 마감일이 현재 날짜보다 앞이면 오류 메세지

### 관련 지라 및 위키 링크
 - [BDBD-153](https://fake-developers.atlassian.net/jira/software/projects/BDBD/boards/10?selectedIssue=BDBD-153)
 
### 리뷰어에게 하고 싶은 말
 - 카테고리 어떤거 넣을지 정해야합니다.
 - 파일 확장자 어떤거 가능하게 할지 정해야합니다.
 - 파일 확장자를 정하는 부분은 많이 부족하다고 생각되오니 좋은 방법 가르쳐주시면 감사하겟습니다.

