### PR TITLE
Feature : `BDBD-358` FirebaseTokenFilter 추가 및 Security Filter Chain에 적용

### DIFF
--- a/src/main/java/com/fakedevelopers/bidderbidder/config/SecurityConfig.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/config/SecurityConfig.java
@@ -1,7 +1,8 @@
 package com.fakedevelopers.bidderbidder.config;
 
+import com.fakedevelopers.bidderbidder.filter.FirebaseTokenFilter;
 import com.google.firebase.auth.FirebaseAuth;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,18 +13,14 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+@RequiredArgsConstructor
 @Configuration
 // 아래는 실제 로직 작성 후 주석 해제
-// @EnableWebSecurity
+@EnableWebSecurity
 
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
-    /*
-        아래는 Custom Filter의 매개변수로 넘길 예정
-     */
-    @Autowired
     private FirebaseAuth firebaseAuth; // Firebase 토큰 정보
-    @Autowired
     private UserDetailsService userDetailsService;
 
     /*
@@ -44,12 +41,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+
         http.csrf().disable()
                 .authorizeRequests()
                 .anyRequest().authenticated()
                 .and()
-                // .addFilterBefore(커스텀 필터 , UsernamePasswordAuthenticationFilter.class)
-
+                .addFilterBefore(new FirebaseTokenFilter(userDetailsService, firebaseAuth), UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling()
                 .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED));
     }

--- a/src/main/java/com/fakedevelopers/bidderbidder/config/SecurityConfig.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/config/SecurityConfig.java
@@ -15,9 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @RequiredArgsConstructor
 @Configuration
-// 아래는 실제 로직 작성 후 주석 해제
 @EnableWebSecurity
-
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private FirebaseAuth firebaseAuth; // Firebase 토큰 정보

--- a/src/main/java/com/fakedevelopers/bidderbidder/filter/FirebaseTokenFilter.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/filter/FirebaseTokenFilter.java
@@ -1,0 +1,78 @@
+package com.fakedevelopers.bidderbidder.filter;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import org.apache.http.HttpStatus;
+import org.springframework.lang.NonNullApi;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.NoSuchElementException;
+
+public class FirebaseTokenFilter extends OncePerRequestFilter {
+    private final UserDetailsService userDetailsService;
+    private final FirebaseAuth firebaseAuth;
+
+    public FirebaseTokenFilter(UserDetailsService userDetailsService, FirebaseAuth firebaseAuth) {
+        this.userDetailsService = userDetailsService;
+        this.firebaseAuth = firebaseAuth;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        // Request에 포함된 token을 저장
+        FirebaseToken decodedToken;
+
+        String header = request.getHeader("Authorization");
+        // Authorization: Bearer ${token} 라는 Header를 포함하는 요청에 대한 필터
+        // https://www.ssemi.net/what-is-the-bearer-authentication/
+
+        if (header == null || !header.startsWith("Bearer ")) {
+            setUnauthorizedResponseMessage(response, "INVALID_HEADER");
+            return;
+        }
+        String token = header.substring(7);
+
+        try {
+            // service provider가 token을 검증
+            decodedToken = firebaseAuth.verifyIdToken(token);
+        } catch (FirebaseAuthException e) {
+            setUnauthorizedResponseMessage(response, "INVALID_TOKEN");
+            return;
+        }
+
+        // 인증 성공시 Spring Security Context에 저장
+        try {
+            // 자원을 요청하는 User의 {고유 ID}를 통해 userDetails를 가져온다.
+            UserDetails userDetails = userDetailsService.loadUserByUsername(decodedToken.getUid());
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        } catch (NoSuchElementException e) {
+            setUnauthorizedResponseMessage(response, "USER_NOT_FOUND");
+            return;
+        }
+        // 이 후, 수행할 Filter Chain 지정
+        filterChain.doFilter(request, response);
+    }
+
+    private void setUnauthorizedResponseMessage(HttpServletResponse responseMessage,
+                                                String typeOfError) throws IOException {
+        responseMessage.setStatus(HttpStatus.SC_UNAUTHORIZED);
+        responseMessage.setContentType("application/json");
+
+        // client에게 반환할 출력 스트림에 error type 표시
+        PrintWriter writer = responseMessage.getWriter();
+        writer.write("{error: \"" + typeOfError + "\"}");
+    }
+}

--- a/src/main/java/com/fakedevelopers/bidderbidder/filter/FirebaseTokenFilter.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/filter/FirebaseTokenFilter.java
@@ -3,8 +3,10 @@ package com.fakedevelopers.bidderbidder.filter;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.FirebaseToken;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
-import org.springframework.lang.NonNullApi;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,19 +17,14 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.NoSuchElementException;
-
+@RequiredArgsConstructor
 public class FirebaseTokenFilter extends OncePerRequestFilter {
     private final UserDetailsService userDetailsService;
     private final FirebaseAuth firebaseAuth;
 
-    public FirebaseTokenFilter(UserDetailsService userDetailsService, FirebaseAuth firebaseAuth) {
-        this.userDetailsService = userDetailsService;
-        this.firebaseAuth = firebaseAuth;
-    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -35,7 +32,7 @@ public class FirebaseTokenFilter extends OncePerRequestFilter {
         // Request에 포함된 token을 저장
         FirebaseToken decodedToken;
 
-        String header = request.getHeader("Authorization");
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         // Authorization: Bearer ${token} 라는 Header를 포함하는 요청에 대한 필터
         // https://www.ssemi.net/what-is-the-bearer-authentication/
 
@@ -72,7 +69,7 @@ public class FirebaseTokenFilter extends OncePerRequestFilter {
     private void setUnauthorizedResponseMessage(HttpServletResponse responseMessage,
                                                 String typeOfError) throws IOException {
         responseMessage.setStatus(HttpStatus.SC_UNAUTHORIZED);
-        responseMessage.setContentType("application/json");
+        responseMessage.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
         // client에게 반환할 출력 스트림에 error type 표시
         PrintWriter writer = responseMessage.getWriter();

--- a/src/main/java/com/fakedevelopers/bidderbidder/filter/FirebaseTokenFilter.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/filter/FirebaseTokenFilter.java
@@ -6,6 +6,7 @@ import com.google.firebase.auth.FirebaseToken;
 import org.apache.http.HttpStatus;
 import org.springframework.lang.NonNullApi;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -58,6 +59,8 @@ public class FirebaseTokenFilter extends OncePerRequestFilter {
             UserDetails userDetails = userDetailsService.loadUserByUsername(decodedToken.getUid());
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            // 최종 인증 결과를 Security Context에 저장, 이후에는 인증 객체를 전역적으로 사용 가능
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (NoSuchElementException e) {
             setUnauthorizedResponseMessage(response, "USER_NOT_FOUND");
             return;


### PR DESCRIPTION
### 개요
Firebase 토큰을 검증하는 Filter정의 및 filter chain 등록

### 변경사항
1. SecurityConfig : 
* 커스텀 필터가 `UsernamePasswordAuthenticationFilter` 이전에 수행될 수 있도록 Filter-chain 설정

2. FirebaseTokenFilter : Firebase 토큰을 검증하는 필터 추가   
* HttpServletRequest에 포함된 `{Authorization: Bearer <토큰>}`에 대한 검증과정 수행
* Request 메세지 형식 검사
* token에 대한 service provider(ex. google) 단에서의 검증
* Resource Owner(= 사용자)에 대한 검증 

### 관련 지라 및 위키 링크
[BDBD-358](https://fake-developers.atlassian.net/browse/BDBD-358?atlOrigin=eyJpIjoiN2VmNjlmMjliOWZkNDRmNWE5MTA1MzZlNWY1NmU5MmQiLCJwIjoiaiJ9)

### 리뷰어에게 하고 싶은 말
* 부족한 점들에 대한 피드백은 언제나 환영합니다 :)