### PR TITLE
FEAT : BDBD-428 에러 핸들러 추가

### DIFF
--- a/src/main/java/com/fakedevelopers/bidderbidder/controller/ControllerExceptionHandler.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/controller/ControllerExceptionHandler.java
@@ -11,16 +11,15 @@ public class ControllerExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   protected ResponseEntity<ErrorResponse> exceptionHandler(Exception e) {
-    return new ResponseEntity<>(
-        new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, e.getMessage()),
-        HttpStatus.INTERNAL_SERVER_ERROR);
+
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body( new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, e.getMessage()));
   }
 
   @ExceptionHandler(HttpException.class)
-  protected ResponseEntity<ErrorResponse> httpExceptionHandler(HttpException e) {
-    return new ResponseEntity<>(
-        new ErrorResponse(e.status.value(), e.code, e.getMessage()),
-        e.status);
+  protected ResponseEntity<ErrorResponse>  httpExceptionHandler(HttpException e) {
+    return ResponseEntity.status(e.status)
+        .body(new ErrorResponse(e.status.value(), e.code, e.getMessage()));
   }
 
   private static class ErrorResponse {

--- a/src/main/java/com/fakedevelopers/bidderbidder/controller/ControllerExceptionHandler.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/controller/ControllerExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.fakedevelopers.bidderbidder.controller;
+
+import com.fakedevelopers.bidderbidder.exception.HttpException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerExceptionHandler {
+
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<ErrorResponse> exceptionHandler(Exception e) {
+    return new ResponseEntity<>(
+        new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, e.getMessage()),
+        HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(HttpException.class)
+  protected ResponseEntity<ErrorResponse> httpExceptionHandler(HttpException e) {
+    return new ResponseEntity<>(
+        new ErrorResponse(e.status.value(), e.code, e.getMessage()),
+        e.status);
+  }
+
+  private static class ErrorResponse {
+
+    final int status;
+    final String message;
+
+    final String code;
+
+    ErrorResponse(int status, String message, String code) {
+      this.status = status;
+      this.message = message;
+      this.code = code;
+    }
+  }
+}

--- a/src/main/java/com/fakedevelopers/bidderbidder/dto/BidDto.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/dto/BidDto.java
@@ -6,12 +6,12 @@ import lombok.Getter;
 public class BidDto {
 
   private final int index;
-  private final String userNickName;
+  private final String userNickname;
   private final long bid;
 
-  BidDto(int index, String userNickName, long bid) {
+  BidDto(int index, String userNickname, long bid) {
     this.index = index;
-    this.userNickName = userNickName;
+    this.userNickname = userNickname;
     this.bid = (index < 4)? -1L : bid; // 1등부터 3등까진 응찰금액을 가린다
   }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/AlreadyExpiredException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/AlreadyExpiredException.java
@@ -1,8 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class AlreadyExpiredException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class AlreadyExpiredException extends HttpException {
 
   public AlreadyExpiredException(String message) {
-    super(message);
+    super(HttpStatus.BAD_REQUEST, message);
   }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/GlobalExceptionHandler.java
@@ -1,35 +1,38 @@
-package com.fakedevelopers.bidderbidder.controller;
+package com.fakedevelopers.bidderbidder.exception;
 
-import com.fakedevelopers.bidderbidder.exception.HttpException;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-public class ControllerExceptionHandler {
+public class GlobalExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   protected ResponseEntity<ErrorResponse> exceptionHandler(Exception e) {
 
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body( new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, e.getMessage()));
+        .body(new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, e.getMessage()));
   }
 
   @ExceptionHandler(HttpException.class)
-  protected ResponseEntity<ErrorResponse>  httpExceptionHandler(HttpException e) {
+  protected ResponseEntity<ErrorResponse> httpExceptionHandler(HttpException e) {
     return ResponseEntity.status(e.status)
         .body(new ErrorResponse(e.status.value(), e.code, e.getMessage()));
   }
 
+  @Getter
+  @JsonInclude(Include.NON_NULL)
   private static class ErrorResponse {
 
-    final int status;
-    final String message;
+    private final int status;
+    private final String message;
+    private final String code;
 
-    final String code;
-
-    ErrorResponse(int status, String message, String code) {
+    ErrorResponse(int status, String code, String message) {
       this.status = status;
       this.message = message;
       this.code = code;

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/HttpException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/HttpException.java
@@ -1,0 +1,21 @@
+package com.fakedevelopers.bidderbidder.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class HttpException extends RuntimeException {
+
+  public final HttpStatus status;
+  public final String code; // 필요시 상세 에러코드를 넣을 예정
+
+  HttpException(HttpStatus status, String message) {
+    super(message);
+    this.status = status;
+    this.code = null;
+  }
+
+  HttpException(HttpStatus status, String code, String message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidBidException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidBidException.java
@@ -1,8 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class InvalidBidException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class InvalidBidException extends HttpException {
 
   public InvalidBidException(String message) {
-    super(message);
+    super(HttpStatus.BAD_REQUEST, message);
   }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidCategoryException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidCategoryException.java
@@ -1,7 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class InvalidCategoryException extends RuntimeException{
-    public InvalidCategoryException(String message){
-        super(message);
+import org.springframework.http.HttpStatus;
+
+public class InvalidCategoryException extends HttpException {
+
+    public InvalidCategoryException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
     }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidExpirationDateException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidExpirationDateException.java
@@ -1,7 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class InvalidExpirationDateException extends RuntimeException{
-    public InvalidExpirationDateException(String message){
-        super(message);
+import org.springframework.http.HttpStatus;
+
+public class InvalidExpirationDateException extends HttpException {
+
+    public InvalidExpirationDateException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
     }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidExtensionException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidExtensionException.java
@@ -1,7 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class InvalidExtensionException extends RuntimeException{
-    public InvalidExtensionException(String message){
-        super(message);
+import org.springframework.http.HttpStatus;
+
+public class InvalidExtensionException extends HttpException {
+
+    public InvalidExtensionException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
     }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidHopePriceException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidHopePriceException.java
@@ -1,7 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class InvalidHopePriceException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class InvalidHopePriceException extends HttpException {
+
     public InvalidHopePriceException(String message) {
-        super(message);
+        super(HttpStatus.BAD_REQUEST, message);
     }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidRepresentPictureIndexException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidRepresentPictureIndexException.java
@@ -1,7 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class InvalidRepresentPictureIndexException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class InvalidRepresentPictureIndexException extends HttpException {
+
     public InvalidRepresentPictureIndexException(String message) {
-        super(message);
+        super(HttpStatus.BAD_REQUEST, message);
     }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidSearchTypeException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/InvalidSearchTypeException.java
@@ -1,5 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class InvalidSearchTypeException extends RuntimeException{
-    public InvalidSearchTypeException(String message) { super(message); }
+import org.springframework.http.HttpStatus;
+
+public class InvalidSearchTypeException extends HttpException {
+
+    public InvalidSearchTypeException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
+    }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/ProductNotFoundException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/ProductNotFoundException.java
@@ -1,8 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class ProductNotFoundException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class ProductNotFoundException extends HttpException {
 
   public ProductNotFoundException(long id) {
-    super("product not found productId : " + id);
+    super(HttpStatus.NOT_FOUND, "product not found productId : " + id);
   }
 }

--- a/src/main/java/com/fakedevelopers/bidderbidder/exception/UserNotFoundException.java
+++ b/src/main/java/com/fakedevelopers/bidderbidder/exception/UserNotFoundException.java
@@ -1,8 +1,10 @@
 package com.fakedevelopers.bidderbidder.exception;
 
-public class UserNotFoundException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class UserNotFoundException extends HttpException {
 
   public UserNotFoundException(long id) {
-    super("user not found userId : " + id);
+    super(HttpStatus.NOT_FOUND, "user not found userId : " + id);
   }
 }


### PR DESCRIPTION
### 개요
- 에러가 발생했을때 메시지가 직관적이지 않았습니다 그것을 직관적으로 변환하였습니다.

### 변경사항
- GlobalExeptionHandler 추가

### 관련 지라 및 위키 링크
 - [BDBD-428](https://fake-developers.atlassian.net/browse/BDBD-428)

### 리뷰어에게 하고 싶은 말
- 이 작업과는 맞지 않지만 어제 한 작업에서 필드명에 오타가 들어가 있어서 그것도 수정했습니다 양해 부탁드립니다
- 앞으로 가능한 모든 에러는 HttpException을 상속받고 httpStatus도 정의해주시면 좋을것 같습니다.
